### PR TITLE
Change onWorksheetRemoved currentWorkbook check

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -509,7 +509,7 @@ fin.desktop.main(function () {
     function onWorksheetRemoved(event) {
         var worksheet = event.worksheet;
 
-        if (worksheet.workbook === currentWorkbook) {
+        if (event.target === currentWorkbook) {
             worksheet.removeEventListener("sheetChanged", onSheetChanged);
             worksheet.removeEventListener("selectionChanged", onSelectionChanged);
             worksheet.removeEventListener("sheetActivated", onSheetActivated);


### PR DESCRIPTION
There is no workbook on the removed worksheet. The Excel API will either need to change to include workbook when it creates this.objectInstance or the event can be changed to include the workbook alongside the removed worksheet. The check has been updated to use the target which is the workbook until the api changes to include workbook in the event (or removed worksheet).