### PR TITLE
Updated to clear rtd cell on provider close

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -493,18 +493,15 @@ rtd.setValue('Topic1', 123.55);
 
 ### Excel RTD Functionality (New in 4.0.0)
 
-From version 4.0 you can dispose the rtd instance that you created. You have the option of specifying whether or not you want pushed values cleared (as you may want some rtd instances to behave differently). You should call dispose if your application is closing or if you no longer need the functionality.
+From version 4.0 you can dispose the rtd instance that you created. You should call dispose if your application is closing or if you no longer need the functionality.
 
 ```javascript
 const rtd = await fin.desktop.ExcelService.createRtd('Provider1');
 
 // Will stop listening to excel and will tell excel to clear all values in the connected topics
+// When the excel provider service closes we will clear the cells as well but that won't happen if another application 
+// is still using the excel service so you should always try and tidy up and dispose when your application is about to close. 
  await rtd.dispose();
-
-// OR
-
-// Will stop listening to excel and but will NOT tell excel to clear all values in the connected topics
- await rtd.dispose(false);
 
 ```
 

--- a/client/fin.desktop.Excel.js
+++ b/client/fin.desktop.Excel.js
@@ -558,7 +558,7 @@ class ExcelApplication extends RpcDispatcher_1.RpcDispatcher {
     constructor(connectionUuid, logger) {
         super(logger);
         this.workbooks = {};
-        this.version = { clientVersion: "4.0.1", buildVersion: "4.0.1.0" };
+        this.version = { clientVersion: "4.0.2", buildVersion: "4.0.2.0" };
         this.loggerName = "ExcelApplication";
         this.processExcelEvent = (data, uuid) => {
             var eventType = data.event;
@@ -890,11 +890,11 @@ class ExcelRtd extends EventEmitter_1.EventEmitter {
         this.logger.trace(this.loggerName + `: Publishing on rtdTopic: ${topic} and provider: ${this.providerName} value: ${JSON.stringify(value)}`);
         fin.InterApplicationBus.publish(`excelRtd/data/${this.providerName}/${topic}`, value);
     }
-    dispose(clearValues = true) {
+    dispose() {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.disposed) {
-                this.logger.debug(this.loggerName + `: dispose called with clearValues: ${clearValues} for this provider (${this.providerName}).`);
-                this.clear(clearValues);
+                this.logger.debug(this.loggerName + `: dispose called. Will send message to clear values for this provider (${this.providerName}).`);
+                this.clear();
                 if (this.provider !== undefined) {
                     try {
                         yield this.provider.destroy();
@@ -989,12 +989,10 @@ class ExcelRtd extends EventEmitter_1.EventEmitter {
         this.logger.debug(this.loggerName + `: Unsubscribe for rtdTopic ${topic}. Dispatching disconnected event for rtdTopic.`);
         this.dispatchEvent(this.disconnectedKey, { topic });
     }
-    clear(clearValues) {
-        if (clearValues) {
-            let path = `excelRtd/clear/${this.providerName}`;
-            this.logger.debug(this.loggerName + `: Clear called specifying clear values: ${clearValues}. Publishing to excel on topic: ${path} `);
-            fin.InterApplicationBus.publish(`excelRtd/clear/${this.providerName}`, clearValues);
-        }
+    clear() {
+        let path = `excelRtd/clear/${this.providerName}`;
+        this.logger.debug(this.loggerName + `: Clear called. Publishing to excel on topic: ${path} `);
+        fin.InterApplicationBus.publish(`excelRtd/clear/${this.providerName}`, true);
     }
 }
 exports.ExcelRtd = ExcelRtd;

--- a/client/src/ExcelRtd.d.ts
+++ b/client/src/ExcelRtd.d.ts
@@ -19,7 +19,7 @@ export declare class ExcelRtd extends EventEmitter {
     get isDisposed(): boolean;
     get isInitialized(): boolean;
     setValue(topic: any, value: any): void;
-    dispose(clearValues?: boolean): Promise<void>;
+    dispose(): Promise<void>;
     addEventListener(type: string, listener: (data?: any) => any): void;
     dispatchEvent(evt: Event): boolean;
     dispatchEvent(typeArg: string, data?: any): boolean;

--- a/client/src/ExcelRtd.js
+++ b/client/src/ExcelRtd.js
@@ -69,11 +69,11 @@ class ExcelRtd extends EventEmitter_1.EventEmitter {
         this.logger.trace(this.loggerName + `: Publishing on rtdTopic: ${topic} and provider: ${this.providerName} value: ${JSON.stringify(value)}`);
         fin.InterApplicationBus.publish(`excelRtd/data/${this.providerName}/${topic}`, value);
     }
-    dispose(clearValues = true) {
+    dispose() {
         return __awaiter(this, void 0, void 0, function* () {
             if (!this.disposed) {
-                this.logger.debug(this.loggerName + `: dispose called with clearValues: ${clearValues} for this provider (${this.providerName}).`);
-                this.clear(clearValues);
+                this.logger.debug(this.loggerName + `: dispose called. Will send message to clear values for this provider (${this.providerName}).`);
+                this.clear();
                 if (this.provider !== undefined) {
                     try {
                         yield this.provider.destroy();
@@ -168,12 +168,10 @@ class ExcelRtd extends EventEmitter_1.EventEmitter {
         this.logger.debug(this.loggerName + `: Unsubscribe for rtdTopic ${topic}. Dispatching disconnected event for rtdTopic.`);
         this.dispatchEvent(this.disconnectedKey, { topic });
     }
-    clear(clearValues) {
-        if (clearValues) {
-            let path = `excelRtd/clear/${this.providerName}`;
-            this.logger.debug(this.loggerName + `: Clear called specifying clear values: ${clearValues}. Publishing to excel on topic: ${path} `);
-            fin.InterApplicationBus.publish(`excelRtd/clear/${this.providerName}`, clearValues);
-        }
+    clear() {
+        let path = `excelRtd/clear/${this.providerName}`;
+        this.logger.debug(this.loggerName + `: Clear called. Publishing to excel on topic: ${path} `);
+        fin.InterApplicationBus.publish(`excelRtd/clear/${this.providerName}`, true);
     }
 }
 exports.ExcelRtd = ExcelRtd;

--- a/client/src/index.d.ts
+++ b/client/src/index.d.ts
@@ -1,1 +1,12 @@
-export {};
+import { ExcelService } from './ExcelApi';
+import { ExcelApplication } from './ExcelApplication';
+declare global {
+    interface Window {
+        fin: {
+            desktop: {
+                ExcelService: ExcelService;
+                Excel: ExcelApplication;
+            };
+        };
+    }
+}

--- a/demo/app.json
+++ b/demo/app.json
@@ -2,9 +2,9 @@
   "licenseKey": "64605fac-add3-48a0-8710-64b38e96a2dd",
   "startup_app": {
     "name": "Excel-API-Example",
-    "url": "https://cdn.openfin.co/release/exceljs/4.0.1/demo/index.html",
+    "url": "https://cdn.openfin.co/release/exceljs/4.0.2/demo/index.html",
     "uuid": "excel-api-example",
-    "applicationIcon": "https://cdn.openfin.co/release/exceljs/4.0.1/demo/openfin-excel.ico",
+    "applicationIcon": "https://cdn.openfin.co/release/exceljs/4.0.2/demo/openfin-excel.ico",
     "autoShow": true,
     "defaultWidth": 760,
     "defaultHeight": 704,
@@ -21,17 +21,17 @@
     "arguments": "",
     "version": "14.78.48.16"
   },
-  "splashScreenImage": "https://cdn.openfin.co/release/exceljs/4.0.1/demo/splash_excel.png",
+  "splashScreenImage": "https://cdn.openfin.co/release/exceljs/4.0.2/demo/splash_excel.png",
   "shortcut": {
     "company": "OpenFin",
     "description": "excel-api-example",
-    "icon": "https://cdn.openfin.co/release/exceljs/4.0.1/demo/openfin-excel.ico",
+    "icon": "https://cdn.openfin.co/release/exceljs/4.0.2/demo/openfin-excel.ico",
     "name": "excel-api-example"
   },
   "services": [
     {
       "name": "excel",
-      "manifestUrl": "https://cdn.openfin.co/release/exceljs/4.0.1/provider/app.json"
+      "manifestUrl": "https://cdn.openfin.co/release/exceljs/4.0.2/provider/app.json"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "excel-api-example",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "excel-api-example",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Excel integration for OpenFin",
   "main": "main.js",
   "dependencies": {},
   "devDependencies": {
-    "http-server": "*",
     "openfin-cli": "*",
+    "http-server": "*",
     "webpack": "^2.5.1"
   },
   "scripts": {

--- a/provider/app.json
+++ b/provider/app.json
@@ -2,7 +2,7 @@
   "licenseKey": "64605fac-add3-48a0-8710-64b38e96a2dd",
   "startup_app": {
     "name": "Excel-Service-Manager",
-    "url": "https://cdn.openfin.co/release/exceljs/4.0.1/provider/provider.html",
+    "url": "https://cdn.openfin.co/release/exceljs/4.0.2/provider/provider.html",
     "uuid": "excel-service-manager",
     "permissions": {
       "System": {
@@ -17,9 +17,9 @@
   },
   "appAssets": [
     {
-      "src": "https://cdn.openfin.co/release/exceljs/4.0.1/provider/add-in.zip",
+      "src": "https://cdn.openfin.co/release/exceljs/4.0.2/provider/add-in.zip",
       "alias": "excel-api-addin",
-      "version": "4.0.1"
+      "version": "4.0.2"
     }
   ]
 }

--- a/provider/dev-app.json
+++ b/provider/dev-app.json
@@ -20,7 +20,7 @@
     {
       "src": "http://localhost:8080/provider/add-in.zip",
       "alias": "excel-api-addin",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "forceDownload": true
     }
   ]

--- a/provider/provider.js
+++ b/provider/provider.js
@@ -83,8 +83,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 // XLL Add-In has been installed. If not, it will perform the deployment, registration,
 // and start the service process
 fin.desktop.main(() => __awaiter(this, void 0, void 0, function* () {
-    const providerVersion = "4.0.1";
-    const buildVersion = "4.0.1.0";
+    const providerVersion = "4.0.2";
+    const buildVersion = "4.0.2.0";
     const excelAssetAlias = 'excel-api-addin';
     const excelServiceUuid = '886834D1-4651-4872-996C-7B2578E953B9';
     const installFolder = '%localappdata%\\OpenFin\\shared\\assets\\excel-api-addin';


### PR DESCRIPTION
Updated dependencies for the add in (around packaging/zipping) to be latest stable.
Removed the option to not clear rtd topic cells when calling dispose as we now clear the cell value when the provider is shutdown.
Updated output of index.d.ts in src so it could be used for typing information.
Updated documentation.